### PR TITLE
changes in seed logic

### DIFF
--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -502,7 +502,10 @@ def oos_can_use_gale_seeds_offensively(state: CollectionState, player: int):
                 oos_has_slingshot(state, player)
             ]),
             all([
-                oos_option_hard_logic(state, player),
+                any([
+                    oos_option_hard_logic(state, player),
+                    oos_has_feather(state, player)
+                ]),
                 oos_has_satchel(state, player)
             ]),
         ])
@@ -630,7 +633,14 @@ def oos_can_kill_normal_using_satchel(state: CollectionState, player: int):
                 oos_option_medium_logic(state, player),
                 any([
                     oos_has_scent_seeds(state, player),
-                    oos_has_gale_seeds(state, player),
+                    all([
+                        oos_has_gale_seeds(state, player),
+                        oos_has_mystery_seeds(state, player),
+                        any([
+                            oos_option_hard_logic(state, player),
+                            oos_has_feather(state, player)
+                        ])
+                    ]),
                 ])
             ])
         ])
@@ -645,6 +655,7 @@ def oos_can_kill_normal_using_slingshot(state: CollectionState, player: int):
             oos_has_scent_seeds(state, player),
             all([
                 oos_option_medium_logic(state, player),
+                oos_has_mystery_seeds(state, player),
                 oos_has_gale_seeds(state, player),
             ])
         ])

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -1,6 +1,7 @@
 from BaseClasses import CollectionState
 from worlds.tloz_oos.data.Constants import DUNGEON_NAMES, SEASON_ITEMS, ESSENCES
 
+
 # Static predicates ############################################################
 
 # These predicates don't require a state but a world instead, and are used before item fill
@@ -494,19 +495,17 @@ def oos_can_warp_using_gale_seeds(state: CollectionState, player: int):
 
 
 def oos_can_use_gale_seeds_offensively(state: CollectionState, player: int):
-    return all([
-        oos_has_gale_seeds(state, player),
-        any([
-            all([
-                oos_option_medium_logic(state, player),
-                oos_has_slingshot(state, player)
-            ]),
-            all([
-                any([
-                    oos_option_hard_logic(state, player),
-                    oos_has_feather(state, player)
-                ]),
-                oos_has_satchel(state, player)
+    # If we don't have gale seeds or aren't at least in medium logic, don't even try
+    if not oos_has_gale_seeds(state, player) or not oos_option_medium_logic(state, player):
+        return False
+
+    return any([
+        oos_has_slingshot(state, player),
+        all([
+            oos_has_satchel(state, player),
+            any([
+                oos_option_hard_logic(state, player),
+                oos_has_feather(state, player)
             ]),
         ])
     ])
@@ -625,24 +624,29 @@ def oos_can_kill_normal_enemy(state: CollectionState, player: int, pit_available
 
 
 def oos_can_kill_normal_using_satchel(state: CollectionState, player: int):
-    return all([
-        oos_has_satchel(state, player),
-        any([
-            oos_has_ember_seeds(state, player),
-            all([
-                oos_option_medium_logic(state, player),
-                any([
-                    oos_has_scent_seeds(state, player),
-                    all([
-                        oos_has_gale_seeds(state, player),
-                        oos_has_mystery_seeds(state, player),
-                        any([
-                            oos_option_hard_logic(state, player),
-                            oos_has_feather(state, player)
-                        ])
-                    ]),
+    # Killing using satchel without satchel is known to be pretty tricky
+    if not oos_has_satchel(state, player):
+        return False
+
+    return any([
+        # Casual logic => only ember
+        oos_has_ember_seeds(state, player),
+        all([
+            # Medium logic => allow scent or gale+feather
+            oos_option_medium_logic(state, player),
+            any([
+                oos_has_scent_seeds(state, player),
+                oos_has_mystery_seeds(state, player),
+                all([
+                    oos_has_gale_seeds(state, player),
+                    oos_has_feather(state, player)
                 ])
             ])
+        ]),
+        all([
+            # Hard logic => allow gale without feather
+            oos_option_hard_logic(state, player),
+            oos_has_gale_seeds(state, player)
         ])
     ])
 
@@ -655,8 +659,10 @@ def oos_can_kill_normal_using_slingshot(state: CollectionState, player: int):
             oos_has_scent_seeds(state, player),
             all([
                 oos_option_medium_logic(state, player),
-                oos_has_mystery_seeds(state, player),
-                oos_has_gale_seeds(state, player),
+                any([
+                    oos_has_mystery_seeds(state, player),
+                    oos_has_gale_seeds(state, player),
+                ])
             ])
         ])
     ])


### PR DESCRIPTION
Few propositions for changes in the logic :
- Since mystery seeds can be used to light torches in medium, it would also make sense to use it to fight since it has 75% chance of helping killing the enemy, and is as hard to use as the scent seed
- oos_can_use_gale_seeds_offensively say you need hard logic, but oos_can_kill_normal_using_satchel ask for medium logic, given how hard it is, I propose to make it hard
- following the previous bullet point, I believe feather is enough to make gale quite handleable in medium, as jumping over an enemy to drop a gale is quite simple