### PR TITLE
Spinner north chest logicall access by killing vire

### DIFF
--- a/worlds/tloz_oos/data/Regions.py
+++ b/worlds/tloz_oos/data/Regions.py
@@ -291,6 +291,7 @@ REGIONS = [
     "d6 armos hall",
     "d6 spinner north",
     "enter vire",
+    "kill vire",
     "d6 pre-boss room",
     "d6 boss",
     "enter d7",

--- a/worlds/tloz_oos/data/logic/DungeonsLogic.py
+++ b/worlds/tloz_oos/data/logic/DungeonsLogic.py
@@ -569,7 +569,7 @@ def make_d6_logic(player: int):
             oos_has_sword(state, player, False),
             oos_has_fools_ore(state, player),
             # state.has("expert's ring", player)
-        ])]
+        ])],
         ["kill vire", "d6 spinner north", False, lambda state: all([
             # Go north by putting taking the spinner once then teleport to the miniboss and walk to the spinner from the left
             oos_can_break_crystal(state, player),

--- a/worlds/tloz_oos/data/logic/DungeonsLogic.py
+++ b/worlds/tloz_oos/data/logic/DungeonsLogic.py
@@ -556,6 +556,7 @@ def make_d6_logic(player: int):
             any([
                 oos_has_small_keys(state, player, 6, 3),
                 all([
+                    # Go through the beamos room
                     oos_has_small_keys(state, player, 6, 2),
                     oos_has_feather(state, player),
                     oos_has_bombs(state, player)
@@ -563,14 +564,28 @@ def make_d6_logic(player: int):
             ])
         ])],
 
-        ["d6 vire chest", "enter vire", False, lambda state: oos_has_small_keys(state, player, 6, 3)],
-        ["enter vire", "d6 pre-boss room", False, lambda state: all([
+        ["d6 vire chest", "kill vire", False, lambda state: any([
+            # Do not require keys yet because this logic is used to get to d6 spinner north
+            oos_has_sword(state, player, False),
+            oos_has_fools_ore(state, player),
+            # state.has("expert's ring", player)
+        ])]
+        ["kill vire", "d6 spinner north", False, lambda state: all([
+            # Go north by putting taking the spinner once then teleport to the miniboss and walk to the spinner from the left
+            oos_can_break_crystal(state, player),
+            oos_has_magnet_gloves(state, player),
             any([
-                # Kill Vire
-                oos_has_sword(state, player, False),
-                oos_has_fools_ore(state, player),
-                # state.has("expert's ring", player)
-            ]),
+                oos_has_small_keys(state, player, 6, 2),
+                all([
+                    # Go through the beamos room
+                    oos_has_small_keys(state, player, 6, 1),
+                    oos_has_feather(state, player),
+                    oos_has_bombs(state, player)
+                ])
+            ])
+        ])],
+        ["kill vire", "d6 pre-boss room", False, lambda state: all([
+            oos_has_small_keys(state, player, 6, 3),  # This wasn't taken in account yet because of the spinner north
             any([
                 # Kill hardhats
                 oos_has_magnet_gloves(state, player),


### PR DESCRIPTION
I know this isn't critical, I'm just proposing to add a bit of logic that allows to get the north chest by going through vire
The logic in this area is not the clearest, the idea there was that if you had 3 keys, you could access it, by unlocking the entrance keyblock, but with 2 keys, you can either unlock the entrance or the beamos room, both leading to the north chest. I added a bit of logic to make it so that with 1 key (and access to the hole at the end of the beamos path, and the ability to kill the boss), no matter where you spend your single key, you can get the chest.