### PR TITLE
Logic fixes, prep for forcing warp to start, prep for alt starting lo…

### DIFF
--- a/worlds/tloz_oos/Logic.py
+++ b/worlds/tloz_oos/Logic.py
@@ -5,7 +5,7 @@ from worlds.tloz_oos.data.logic.OverworldLogic import make_holodrum_logic
 from worlds.tloz_oos.data.logic.SubrosiaLogic import make_subrosia_logic
 
 
-def create_connections(multiworld: MultiWorld, player: int):
+def create_connections(multiworld: MultiWorld, player: int, origin_name: str):
     dungeon_entrances = []
     for reg1, reg2 in multiworld.worlds[player].dungeon_entrances.items():
         dungeon_entrances.append([reg1, reg2, True, None])
@@ -15,7 +15,7 @@ def create_connections(multiworld: MultiWorld, player: int):
         portal_connections.append([reg1, reg2, True, None])
 
     all_logic = [
-        make_holodrum_logic(player),
+        make_holodrum_logic(player, origin_name),
         make_subrosia_logic(player),
         make_d0_logic(player),
         make_d1_logic(player),

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -791,7 +791,7 @@ class OracleOfSeasonsWorld(World):
                    "sign_guy_requirement", "golden_beasts_requirement",
                    # Tracker QoL
                    "enforce_potion_in_shop", "keysanity_small_keys", "keysanity_boss_keys", "starting_maps_compasses",
-                   "deterministic_gasha_locations"
+                   "deterministic_gasha_locations", "shuffle_business_scrubs", "shop_prices"
                    ]
 
         slot_data = self.options.as_dict(*options)
@@ -805,7 +805,6 @@ class OracleOfSeasonsWorld(World):
 
         slot_data["dungeon_entrances"] = self.dungeon_entrances
         slot_data["portal_connections"] = self.portal_connections
-        slot_data["shop_prices"] = self.shop_prices
         slot_data["shop_order"] = self.shop_order
         slot_data["shop_rupee_requirements"] = self.shop_rupee_requirements
 

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -102,6 +102,7 @@ class OracleOfSeasonsWorld(World):
     item_name_to_id = build_item_name_to_id_dict()
     item_name_groups = ITEM_GROUPS
     location_name_groups = LOCATION_GROUPS
+    origin_region_name = "impa's house"
 
     def __init__(self, multiworld, player):
         super().__init__(multiworld, player)

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -530,6 +530,11 @@ class OracleOfSeasonsWorld(World):
             self.remaining_progressive_gasha_seeds -= 1
             classification = ItemClassification.progression
 
+        # Players in Medium+ are expected to know the default paths through Lost Woods, Phonograph becomes filler
+        difficulties = ["medium", "hard"]
+        if self.options.logic_difficulty in difficulties and not self.options.randomize_lost_woods_item_sequence and name == "Phonograph":
+            classification = ItemClassification.filler
+
         return Item(name, classification, ap_code, self.player)
 
     def build_item_pool_dict(self):

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -807,6 +807,7 @@ class OracleOfSeasonsWorld(World):
         slot_data["portal_connections"] = self.portal_connections
         slot_data["shop_order"] = self.shop_order
         slot_data["shop_rupee_requirements"] = self.shop_rupee_requirements
+        slot_data["shop_costs"] = self.shop_prices
 
         return slot_data
 

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -507,7 +507,7 @@ class OracleOfSeasonsWorld(World):
             self.multiworld.get_location(name, self.player).progress_type = LocationProgressType.EXCLUDED
 
     def set_rules(self):
-        create_connections(self.multiworld, self.player)
+        create_connections(self.multiworld, self.player, self.origin_region_name)
         apply_self_locking_rules(self.multiworld, self.player)
         self.multiworld.completion_condition[self.player] = lambda state: state.has("_beaten_game", self.player)
 
@@ -805,6 +805,9 @@ class OracleOfSeasonsWorld(World):
 
         slot_data["dungeon_entrances"] = self.dungeon_entrances
         slot_data["portal_connections"] = self.portal_connections
+        slot_data["shop_prices"] = self.shop_prices
+        slot_data["shop_order"] = self.shop_order
+        slot_data["shop_rupee_requirements"] = self.shop_rupee_requirements
 
         return slot_data
 

--- a/worlds/tloz_oos/data/Regions.py
+++ b/worlds/tloz_oos/data/Regions.py
@@ -14,6 +14,7 @@ REGIONS = [
     "syrup trade",
     "syrup shop",
     "mrs. ruul trade",
+    "maple encounter",
     "maple trade",
     "subrosian chef trade",
     "biggoron trade",

--- a/worlds/tloz_oos/data/Regions.py
+++ b/worlds/tloz_oos/data/Regions.py
@@ -1,5 +1,6 @@
 REGIONS = [
     "Menu",
+    "impa's house",
     "horon village",
     "horon village portal",
     "horon village tree",
@@ -29,6 +30,7 @@ REGIONS = [
     "maku tree, 7 essences",
     "horon shop",
     "member's shop",
+    "western coast",
     "black beast's chest",
     "d0 entrance",
     "western coast after ship",

--- a/worlds/tloz_oos/data/Regions.py
+++ b/worlds/tloz_oos/data/Regions.py
@@ -1,5 +1,4 @@
 REGIONS = [
-    "Menu",
     "impa's house",
     "horon village",
     "horon village portal",

--- a/worlds/tloz_oos/data/logic/DungeonsLogic.py
+++ b/worlds/tloz_oos/data/logic/DungeonsLogic.py
@@ -5,20 +5,10 @@ def make_d0_logic(player: int):
     return [
         # 0 keys
         ["enter d0", "d0 key chest", False, None],
-        ["enter d0", "d0 rupee chest", False, lambda state: any([
-            all([
-                oos_can_break_bush(state, player, True),
-                # If dungeons are shuffled, jumping down the hole is a dangerous action and requires
-                # a way of warping back to be in logic
-                any([
-                    not oos_option_shuffled_dungeons(state, player),
-                    oos_can_warp(state, player)
-                ])
-            ]),
-
+        ["enter d0", "d0 rupee chest", False, lambda state: 
             # If hole is removed, stairs are added inside dungeon to make the chest reachable
             oos_option_no_d0_alt_entrance(state, player),
-        ])],
+        ],
         ["d0 rupee chest", "enter d0", False, None],
         ["enter d0", "d0 hidden 2d section", False, lambda state: any([
             oos_can_kill_normal_enemy(state, player),
@@ -107,15 +97,8 @@ def make_d2_logic(player: int):
         ["d2 torch room", "d2 rope drop", False, lambda state: oos_can_kill_normal_enemy(state, player)],
         ["d2 torch room", "d2 arrow room", False, lambda state: oos_can_use_ember_seeds(state, player, True)],
 
-        ["d2 arrow room", "d2 torch room", False, lambda state: all([
-            oos_can_kill_normal_enemy(state, player),
-            any([
-                # Backwards path is one-way if we don't have ember seeds, so ensure we have a way to warp out in case
-                # something goes wrong
-                oos_can_use_ember_seeds(state, player, True),
-                oos_can_warp(state, player)
-            ])
-        ])],
+        ["d2 arrow room", "d2 torch room", False, lambda state:
+            oos_can_kill_normal_enemy(state, player)],
         ["d2 arrow room", "d2 rupee room", False, lambda state: oos_has_bombs(state, player)],
         ["d2 arrow room", "d2 rope chest", False, lambda state: oos_can_kill_normal_enemy(state, player)],
         ["d2 arrow room", "d2 blade chest", False, lambda state: oos_can_kill_normal_enemy(state, player)],

--- a/worlds/tloz_oos/data/logic/DungeonsLogic.py
+++ b/worlds/tloz_oos/data/logic/DungeonsLogic.py
@@ -92,7 +92,7 @@ def make_d1_logic(player: int):
 def make_d2_logic(player: int):
     return [
         # 0 keys
-        ["enter d2", "d2 torch room", False, None],
+        ["enter d2", "d2 torch room", True, None],
         ["d2 torch room", "d2 left from entrance", False, None],
         ["d2 torch room", "d2 rope drop", False, lambda state: oos_can_kill_normal_enemy(state, player)],
         ["d2 torch room", "d2 arrow room", False, lambda state: oos_can_use_ember_seeds(state, player, True)],

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -218,12 +218,12 @@ def oos_can_reach_lost_woods_pedestal(state: CollectionState, player: int, allow
     ])
 
 
-def oos_can_complete_lost_woods_main_sequence(state: CollectionState, player: int):
+def oos_can_complete_lost_woods_main_sequence(state: CollectionState, player: int, allow_default: bool = False):
     world = state.multiworld.worlds[player]
     seasons_in_main_sequence = [season for [_, season] in world.lost_woods_main_sequence]
 
     return all([
-        oos_can_complete_season_sequence(state, player, seasons_in_main_sequence),
+        oos_can_complete_season_sequence(state, player, seasons_in_main_sequence, allow_default),
         any([
             all([
                 oos_can_break_mushroom(state, player, False),

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -831,6 +831,7 @@ def oos_can_trigger_lever_from_minecart(state: CollectionState, player: int):
 
         oos_can_use_scent_seeds(state, player),
         oos_can_use_mystery_seeds(state, player),
+        oos_can_use_ember_seeds(state, player),
         oos_has_slingshot(state, player),  # any seed works using slingshot
     ])
 

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -823,6 +823,7 @@ def oos_can_trigger_lever(state: CollectionState, player: int):
 
 def oos_can_trigger_lever_from_minecart(state: CollectionState, player: int):
     return any([
+        oos_can_punch(state, player),
         oos_has_sword(state, player),
         oos_has_fools_ore(state, player),
         oos_has_boomerang(state, player),

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -198,14 +198,23 @@ def oos_has_required_jewels(state: CollectionState, player: int):
     return count >= target_count
 
 
-def oos_can_reach_lost_woods_pedestal(state: CollectionState, player: int):
+def oos_can_reach_lost_woods_pedestal(state: CollectionState, player: int, allow_default: bool = False):
     world = state.multiworld.worlds[player]
     seasons_in_pedestal_sequence = [season for [_, season] in world.lost_woods_item_sequence]
 
     return all([
-        oos_can_use_ember_seeds(state, player, False),
-        state.has("Phonograph", player),
-        oos_can_complete_season_sequence(state, player, seasons_in_pedestal_sequence)
+        oos_can_complete_season_sequence(state, player, seasons_in_pedestal_sequence, allow_default),
+        any([
+            all([
+                oos_can_use_ember_seeds(state, player, False),
+                state.has("Phonograph", player)
+            ]),
+            all([
+                # if sequence is vanilla, medium+ players are expected to know it
+                oos_option_medium_logic(state, player),
+                not state.multiworld.worlds[player].options.randomize_lost_woods_item_sequence # .value ?
+            ])
+        ])
     ])
 
 
@@ -214,16 +223,25 @@ def oos_can_complete_lost_woods_main_sequence(state: CollectionState, player: in
     seasons_in_main_sequence = [season for [_, season] in world.lost_woods_main_sequence]
 
     return all([
-        oos_can_break_mushroom(state, player, False),
-        oos_has_shield(state, player),
-        oos_can_complete_season_sequence(state, player, seasons_in_main_sequence)
+        oos_can_complete_season_sequence(state, player, seasons_in_main_sequence),
+        any([
+            all([
+                oos_can_break_mushroom(state, player, False),
+                oos_has_shield(state, player)
+            ]),
+            all([
+                # if sequence is vanilla, medium+ players are expected to know it
+                oos_option_medium_logic(state, player),
+                not state.multiworld.worlds[player].options.randomize_lost_woods_main_sequence # .value ?
+            ])
+        ])
     ])
 
 
-def oos_can_complete_season_sequence(state: CollectionState, player: int, season_sequence: list[int]):
+def oos_can_complete_season_sequence(state: CollectionState, player: int, season_sequence: list[int], allow_default: bool = False):
     # In medium logic and above, it is assumed the player can exploit the default season from Lost Woods to cheese
     # the first few seasons of the sequence even if they don't own the matching rod.
-    if oos_option_medium_logic(state, player):
+    if allow_default and oos_option_medium_logic(state, player):
         default_season = oos_get_default_season(state, player, "LOST_WOODS")
         while len(season_sequence) > 0 and season_sequence[0] == default_season:
             del season_sequence[0]
@@ -553,13 +571,6 @@ def oos_can_use_pegasus_seeds(state: CollectionState, player: int):
     ])
 
 
-def oos_can_warp_using_gale_seeds(state: CollectionState, player: int):
-    return all([
-        oos_has_satchel(state, player),
-        oos_has_gale_seeds(state, player)
-    ])
-
-
 def oos_can_use_gale_seeds_offensively(state: CollectionState, player: int):
     # If we don't have gale seeds or aren't at least in medium logic, don't even try
     if not oos_has_gale_seeds(state, player) or not oos_option_medium_logic(state, player):
@@ -577,13 +588,6 @@ def oos_can_use_gale_seeds_offensively(state: CollectionState, player: int):
     ])
 
 
-def oos_can_warp(state: CollectionState, player: int):
-    # Never expect points of no return / risky checks for casual logic
-    if not oos_option_medium_logic(state, player):
-        return False
-    return oos_can_warp_using_gale_seeds(state, player) or oos_option_allow_warp_to_start(state, player)
-
-
 def oos_can_use_mystery_seeds(state: CollectionState, player: int):
     return all([
         oos_can_use_seeds(state, player),
@@ -595,20 +599,8 @@ def oos_can_use_mystery_seeds(state: CollectionState, player: int):
 
 def oos_can_break_bush(state: CollectionState, player: int, can_summon_companion: bool = False):
     return any([
-        oos_has_sword(state, player),
-        oos_has_magic_boomerang(state, player),
-        oos_has_bracelet(state, player),
-        (can_summon_companion and oos_has_flute(state, player)),
-        all([
-            # Consumables need at least medium logic, since they need a good knowledge of the game
-            # not to be frustrating
-            oos_option_medium_logic(state, player),
-            any([
-                oos_has_bombs(state, player, 2),
-                oos_can_use_ember_seeds(state, player, False),
-                (oos_has_slingshot(state, player) and oos_has_gale_seeds(state, player)),
-            ])
-        ]),
+        oos_can_break_flowers(state, player, can_summon_companion),
+        oos_has_bracelet(state, player)
     ])
 
 
@@ -641,7 +633,7 @@ def oos_can_break_pot(state: CollectionState, player: int):
     ])
 
 
-def oos_can_break_flowers(state: CollectionState, player: int, can_summon_companion: bool):
+def oos_can_break_flowers(state: CollectionState, player: int, can_summon_companion: bool = False):
     return any([
         oos_has_sword(state, player),
         oos_has_magic_boomerang(state, player),
@@ -703,8 +695,7 @@ def oos_can_harvest_gasha(state: CollectionState, player: int, count: int):
     return all([
         reachable_soils.count(True) >= count,  # Enough soils are reachable
         state.has("Gasha Seed", player, count),  # Enough seeds to plant
-        oos_can_kill_normal_enemy(state, player),  # Can increase kill count to make the tree grow
-        oos_has_sword(state, player) or oos_has_fools_ore(state, player)  # Can actually harvest the nut
+        oos_has_sword(state, player) or oos_has_fools_ore(state, player)  # Can actually harvest the nut, and get kills
     ])
 
 

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -212,7 +212,7 @@ def oos_can_reach_lost_woods_pedestal(state: CollectionState, player: int, allow
             all([
                 # if sequence is vanilla, medium+ players are expected to know it
                 oos_option_medium_logic(state, player),
-                not state.multiworld.worlds[player].options.randomize_lost_woods_item_sequence # .value ?
+                not state.multiworld.worlds[player].options.randomize_lost_woods_item_sequence
             ])
         ])
     ])
@@ -232,7 +232,7 @@ def oos_can_complete_lost_woods_main_sequence(state: CollectionState, player: in
             all([
                 # if sequence is vanilla, medium+ players are expected to know it
                 oos_option_medium_logic(state, player),
-                not state.multiworld.worlds[player].options.randomize_lost_woods_main_sequence # .value ?
+                not state.multiworld.worlds[player].options.randomize_lost_woods_main_sequence
             ])
         ])
     ])
@@ -830,7 +830,8 @@ def oos_can_trigger_lever_from_minecart(state: CollectionState, player: int):
         oos_has_rod(state, player),
 
         oos_can_use_scent_seeds(state, player),
-        oos_can_use_ember_seeds(state, player, True),
+        oos_can_use_mystery_seeds(state, player),
+        oos_can_use_ember_seeds(state, player, False),
         oos_has_slingshot(state, player),  # any seed works using slingshot
     ])
 

--- a/worlds/tloz_oos/data/logic/LogicPredicates.py
+++ b/worlds/tloz_oos/data/logic/LogicPredicates.py
@@ -830,8 +830,7 @@ def oos_can_trigger_lever_from_minecart(state: CollectionState, player: int):
         oos_has_rod(state, player),
 
         oos_can_use_scent_seeds(state, player),
-        oos_can_use_mystery_seeds(state, player),
-        oos_can_use_ember_seeds(state, player),
+        oos_can_use_ember_seeds(state, player, True),
         oos_has_slingshot(state, player),  # any seed works using slingshot
     ])
 

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -1033,53 +1033,62 @@ def make_holodrum_logic(player: int):
             ])
         ])],
         
-        ["temple remains lower stump", "temple remains upper stump", False, lambda state: all([
-            # connection is useless once volcano is triggered
-            # just block it so it's less confusing for logic
-            not state.has("_triggered_volcano", player),
-            any([
-                all([  # Winter rule
-                    oos_season_in_temple_remains(state, player, SEASON_WINTER),
-                    oos_can_remove_snow(state, player, False),
-                    oos_can_break_bush(state, player, False),
-                    oos_can_jump_6_wide_pit(state, player)
-                ]),
-                all([  # Summer rule
-                    oos_season_in_temple_remains(state, player, SEASON_SUMMER),
-                    oos_can_break_bush(state, player, False),
-                    oos_can_jump_6_wide_pit(state, player)
-                ]),
-                all([  # Spring rule
-                    oos_season_in_temple_remains(state, player, SEASON_SPRING),
-                    oos_can_break_flowers(state, player),
-                    oos_can_break_bush(state, player, False),
-                    oos_can_jump_6_wide_pit(state, player)
-                ]),
-                all([  # Autumn rule
-                    oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
-                    oos_can_break_bush(state, player)
-                ])
+        ["temple remains lower stump", "temple remains upper stump", False, lambda state: any([
+            all([  # Volcano rule
+                state.has("_triggered_volcano", player),
+                oos_has_feather(state, player)
+            ]),
+            all([  # Winter rule
+                not state.has("_triggered_volcano", player),
+                oos_season_in_temple_remains(state, player, SEASON_WINTER),
+                oos_can_remove_snow(state, player, False),
+                oos_can_break_bush(state, player, False),
+                oos_can_jump_6_wide_pit(state, player)
+            ]),
+            all([  # Summer rule
+                not state.has("_triggered_volcano", player),
+                oos_season_in_temple_remains(state, player, SEASON_SUMMER),
+                oos_can_break_bush(state, player, False),
+                oos_can_jump_6_wide_pit(state, player)
+            ]),
+            all([  # Spring rule
+                not state.has("_triggered_volcano", player),
+                oos_season_in_temple_remains(state, player, SEASON_SPRING),
+                oos_can_break_flowers(state, player),
+                oos_can_break_bush(state, player, False),
+                oos_can_jump_6_wide_pit(state, player)
+            ]),
+            all([  # Autumn rule
+                not state.has("_triggered_volcano", player),
+                oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
+                oos_can_break_bush(state, player)
             ])
         ])],
         ["temple remains upper stump", "temple remains lower stump", False, lambda state: all([
-            # connection is useless once volcano is triggered
-            # just block it so it's less confusing for logic
-            not state.has("_triggered_volcano", player),
             any([
-                # Winter rule
-                oos_season_in_temple_remains(state, player, SEASON_WINTER),
+                all([  # Volcano rule
+                    state.has("_triggered_volcano", player),
+                    oos_has_feather(state, player)
+                ]),
+                all([  # Winter rule
+                    not state.has("_triggered_volcano", player),
+                    oos_season_in_temple_remains(state, player, SEASON_WINTER),
+                ]),
                 all([  # Summer rule
+                    not state.has("_triggered_volcano", player),
                     oos_season_in_temple_remains(state, player, SEASON_SUMMER),
                     oos_can_break_bush(state, player, False),
                     oos_can_jump_6_wide_pit(state, player)
                 ]),
                 all([  # Spring rule
+                    not state.has("_triggered_volcano", player),
                     oos_season_in_temple_remains(state, player, SEASON_SPRING),
                     oos_can_break_flowers(state, player),
                     oos_can_break_bush(state, player, False),
                     oos_can_jump_6_wide_pit(state, player)
                 ]),
                 all([  # Autumn rule
+                    not state.has("_triggered_volcano", player),
                     oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
                     oos_can_break_bush(state, player)
                 ])
@@ -1091,12 +1100,16 @@ def make_holodrum_logic(player: int):
             oos_has_feather(state, player)
         ])],
 
-        ["temple remains upper stump", "temple remains lower portal access", False, lambda state: all([
-            # connection is useless once volcano is triggered
-            # just block it so it's less confusing for logic
-            not state.has("_triggered_volcano", player),
-            oos_has_winter(state, player),
-            oos_has_feather(state, player)
+        ["temple remains upper stump", "temple remains lower portal access", False, lambda state: any([
+            all([
+                not state.has("_triggered_volcano", player),
+                oos_has_winter(state, player),
+                oos_has_feather(state, player)
+            ]),
+            all([
+                state.has("_triggered_volcano", player),
+                oos_has_feather(state, player)
+            ])
         ])],
 
         ["temple remains lower portal access", "temple remains lower portal", True, None],
@@ -1124,12 +1137,8 @@ def make_holodrum_logic(player: int):
             oos_can_jump_1_wide_liquid(state, player, False)
         ])],
 
-        ["temple remains upper portal", "temple remains upper stump", False, lambda state: all([
-            # connection is useless once volcano is triggered
-            # just block it so it's less confusing for logic
-            not state.has("_triggered_volcano", player),
-            oos_can_jump_1_wide_pit(state, player, False)
-        ])],
+        ["temple remains upper portal", "temple remains upper stump", False, lambda state:
+            oos_can_jump_1_wide_pit(state, player, False)],
 
         ["temple remains upper portal", "temple remains lower portal access", False, lambda state: any([
             oos_can_jump_1_wide_pit(state, player, False),

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -3,8 +3,9 @@ from .LogicPredicates import *
 
 def make_holodrum_logic(player: int):
     return [
-        ["Menu", "horon village", False, None],
+        ["Menu", "impa's house", False, None],
 
+        ["impa's house", "horon village", True, None]
         ["horon village", "mayor's gift", False, None],
         ["horon village", "vasu's gift", False, None],
         ["horon village", "mayor's house secret room", False, lambda state: oos_has_bombs(state, player)],
@@ -33,14 +34,6 @@ def make_holodrum_logic(player: int):
             oos_can_break_mushroom(state, player, True)
         ])],
 
-        ["horon village", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
-
         ["horon village", "horon village portal", False, lambda state: any([
             oos_has_magic_boomerang(state, player),
             oos_can_jump_6_wide_pit(state, player)
@@ -63,7 +56,15 @@ def make_holodrum_logic(player: int):
 
         # WESTERN COAST ##############################################################################################
 
-        ["horon village", "black beast's chest", False, lambda state: all([
+        ["horon village", "western coast", True, None],
+        ["western coast", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+        ["western coast", "black beast's chest", False, lambda state: all([
             all([
                 oos_has_slingshot(state, player),
                 oos_can_use_ember_seeds(state, player, True),
@@ -72,7 +73,14 @@ def make_holodrum_logic(player: int):
             oos_can_kill_armored_enemy(state, player),
         ])],
 
-        ["horon village", "d0 entrance", True, None],
+        ["western coast", "d0 entrance", True, None],
+        ["western coast", "d0 rupee chest", False, lambda state: 
+            oos_can_break_bush(state, player, True)],
+
+        ["western coast after ship", "western coast", False, lambda state: all([
+            state.has("_met_pirates", player),
+            state.has("Pirate's Bell", player)
+        ])],
 
         ["western coast after ship", "coast stump", False, lambda state: all([
             oos_has_bombs(state, player),
@@ -82,23 +90,26 @@ def make_holodrum_logic(player: int):
             ])
         ])],
 
-        ["western coast after ship",  "old man near western coast house", False, lambda state: \
+        ["western coast after ship", "old man near western coast house", False, lambda state: \
             oos_can_use_ember_seeds(state, player, False)],
 
         ["western coast after ship", "graveyard (winter)", False, lambda state: all([
             oos_can_jump_3_wide_pit(state, player),
             oos_season_in_western_coast(state, player, SEASON_WINTER)
         ])],
+        ["graveyard (winter)", "western coast after ship", False, None],
 
         ["western coast after ship", "graveyard (autumn)", False, lambda state: all([
             oos_can_jump_3_wide_pit(state, player),
             oos_season_in_western_coast(state, player, SEASON_AUTUMN)
         ])],
+        ["graveyard (autumn)", "western coast after ship", False, None],
 
         ["western coast after ship", "graveyard (summer or spring)", False, lambda state: any([
             oos_can_jump_3_wide_pit(state, player),
             oos_season_in_western_coast(state, player, SEASON_SUMMER)
         ])],
+        ["graveyard (summer or spring)", "western coast after ship", False, None],
 
         ["graveyard (winter)", "d7 entrance", False, lambda state: oos_can_remove_snow(state, player, False)],
         ["graveyard (autumn)", "d7 entrance", False, None],
@@ -117,6 +128,13 @@ def make_holodrum_logic(player: int):
 
         ["horon village", "suburbs", True, lambda state: oos_can_use_ember_seeds(state, player, False)],
 
+        ["suburbs", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
         ["suburbs", "windmill heart piece", False, lambda state: oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)],
         ["suburbs", "guru-guru trade", False, lambda state: any([
             state.has("Engine Grease", player),
@@ -139,8 +157,22 @@ def make_holodrum_logic(player: int):
             oos_can_swim(state, player, True),
             oos_can_jump_1_wide_liquid(state, player, True)
         ])],
+        ["suburbs fairy fountain", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
         ["suburbs", "suburbs fairy fountain (winter)", True, lambda state: any([
             oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)
+        ])],
+        ["suburbs fairy fountain (winter)", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
         ])],
         ["suburbs fairy fountain (winter)", "suburbs fairy fountain", False, lambda state: \
             oos_can_remove_season(state, player, SEASON_WINTER)],
@@ -149,30 +181,28 @@ def make_holodrum_logic(player: int):
 
         ["suburbs fairy fountain", "sunken city", False, lambda state: \
             oos_season_in_eastern_suburbs(state, player, SEASON_SPRING)],
-        ["sunken city", "suburbs fairy fountain", False, lambda state: any([
-            oos_season_in_eastern_suburbs(state, player, SEASON_SPRING),
-            oos_can_warp(state, player)
-        ])],
+        ["sunken city", "suburbs fairy fountain", False, lambda state: 
+            oos_season_in_eastern_suburbs(state, player, SEASON_SPRING)],
 
         # WOODS OF WINTER / 2D SECTOR ################################################################################
 
-        ["suburbs fairy fountain (winter)", "moblin road", False, lambda state: None],
+        ["suburbs fairy fountain (winter)", "moblin road", False, None],
         ["moblin road", "suburbs fairy fountain (winter)", False, lambda state: \
             oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)],
+        
+        ["moblin road", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
 
         ["sunken city", "moblin road", False, lambda state: all([
             oos_has_flippers(state, player),
             any([
                 oos_get_default_season(state, player, "SUNKEN_CITY") != SEASON_WINTER,
                 oos_can_remove_season(state, player, SEASON_WINTER)
-            ]),
-            any([
-                oos_can_warp(state, player),
-                all([
-                    # We need both seasons to be able to climb back up
-                    oos_season_in_eastern_suburbs(state, player, SEASON_WINTER),
-                    oos_has_spring(state, player)
-                ])
             ])
         ])],
 
@@ -201,7 +231,7 @@ def make_holodrum_logic(player: int):
             oos_can_jump_1_wide_liquid(state, player, True)
         ])],
 
-        ["suburbs fairy fountain", "central woods of winter", False, lambda state: None],
+        ["suburbs fairy fountain", "central woods of winter", False, None],
         ["suburbs fairy fountain (winter)", "central woods of winter", False, lambda state: any([
             oos_can_jump_1_wide_pit(state, player, True),
             oos_can_remove_snow(state, player, True)
@@ -225,15 +255,28 @@ def make_holodrum_logic(player: int):
 
         # EYEGLASS LAKE SECTOR #########################################################################################
 
-        ["horon village", "eyeglass lake, across bridge", False, lambda state: any([
+        ["impa's house", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+        ["impa's house", "eyeglass lake, across bridge", False, lambda state: any([
             oos_can_jump_4_wide_pit(state, player),
             all([
-                oos_season_in_eyeglass_lake(state, player, SEASON_AUTUMN),
-                oos_has_feather(state, player)
+                oos_has_feather(state, player),
+                any([
+                    oos_get_default_season(state, player, "EYEGLASS_LAKE") == SEASON_AUTUMN,
+                    all([
+                        oos_has_autumn(state, player),
+                        oos_can_break_bush(state, player, True)
+                    ])
+                ])
             ])
         ])],
 
-        ["horon village", "d1 stump", True, lambda state: oos_can_break_bush(state, player, True)],
+        ["impa's house", "d1 stump", True, lambda state: oos_can_break_bush(state, player, True)],
         ["d1 stump", "north horon", True, lambda state: oos_has_bracelet(state, player)],
         ["d1 stump", "malon trade", False, lambda state: any([
             state.has("Cuccodex", player),
@@ -244,7 +287,13 @@ def make_holodrum_logic(player: int):
 
         ["d1 island", "d1 entrance", True, lambda state: state.has("Gnarled Key", player)],
         ["d1 island", "golden beasts old man", False, lambda state: all([
-            oos_season_in_eyeglass_lake(state, player, SEASON_SUMMER),
+            any([
+                oos_get_default_season(state, player, "EYEGLASS_LAKE") == SEASON_SUMMER,
+                all([
+                    oos_has_summer(state, player),
+                    oos_can_break_bush(state, player, True)
+                ])
+            ]),
             oos_can_beat_required_golden_beasts(state, player)
         ])],
 
@@ -273,6 +322,14 @@ def make_holodrum_logic(player: int):
             oos_can_jump_1_wide_pit(state, player, True)
         ])],
 
+        ["d5 stump", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+
         ["d5 stump", "eyeglass lake (default)", True, lambda state: all([
             any([
                 oos_season_in_eyeglass_lake(state, player, SEASON_SPRING),
@@ -284,8 +341,8 @@ def make_holodrum_logic(player: int):
             oos_season_in_eyeglass_lake(state, player, SEASON_SUMMER),
             oos_can_swim(state, player, False)
         ])],
-        ["d5 stump", "eyeglass lake (frozen)", True,
-         lambda state: oos_season_in_eyeglass_lake(state, player, SEASON_WINTER)],
+        ["d5 stump", "eyeglass lake (frozen)", True, lambda state:
+            oos_season_in_eyeglass_lake(state, player, SEASON_WINTER)],
 
         ["eyeglass lake portal", "eyeglass lake (default)", False, lambda state: all([
             oos_get_default_season(state, player, "EYEGLASS_LAKE") in [SEASON_AUTUMN, SEASON_SPRING],
@@ -303,7 +360,7 @@ def make_holodrum_logic(player: int):
             oos_can_swim(state, player, True),
             oos_can_jump_5_wide_liquid(state, player)
         ])],
-        ["eyeglass lake portal", "eyeglass lake (dry)", False, lambda state: \
+        ["eyeglass lake portal", "eyeglass lake (dry)", False, lambda state:
             oos_get_default_season(state, player, "EYEGLASS_LAKE") == SEASON_SUMMER],
 
         ["eyeglass lake (dry)", "dry eyeglass lake, west cave", False, lambda state: all([
@@ -342,10 +399,7 @@ def make_holodrum_logic(player: int):
         ])],
 
         ["d5 entrance", "d5 stump", False, lambda state: any([
-            all([
-                oos_can_warp(state, player),  # jumping off the cliff is a dangerous action
-                oos_can_jump_1_wide_pit(state, player, True)
-            ]),
+            oos_can_jump_1_wide_pit(state, player, True),
             all([
                 oos_get_default_season(state, player, "EYEGLASS_LAKE") == SEASON_AUTUMN,
                 oos_can_break_mushroom(state, player, False)
@@ -365,6 +419,13 @@ def make_holodrum_logic(player: int):
 
         # NORTH HORON / HOLODRUM PLAIN ###############################################################################
 
+        ["north horon", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
         ["north horon", "north horon tree", False, lambda state: oos_can_harvest_tree(state, player, True)],
         ["north horon", "blaino prize", False, lambda state: oos_can_farm_rupees(state, player)],
         ["north horon", "cave north of D1", False, lambda state: all([
@@ -373,15 +434,34 @@ def make_holodrum_logic(player: int):
             oos_has_flippers(state, player)
         ])],
         ["north horon", "old man near blaino", False, lambda state: all([
+            oos_can_use_ember_seeds(state, player, False),
             any([
-                oos_season_in_holodrum_plain(state, player, SEASON_SUMMER),
-                oos_can_summon_ricky(state, player)
-            ]),
-            oos_can_use_ember_seeds(state, player, False)
+                oos_get_default_season(state, player, "HOLODRUM_PLAIN") == SEASON_SUMMER,
+                oos_can_summon_ricky(state, player),
+                all([
+                    # can get from the stump to old man in summer
+                    oos_has_summer(state, player),
+                    any([
+                        oos_has_feather(state, player),
+                        all([
+                            oos_can_break_bush(state, player, True),
+                            oos_can_swim(state, player, True)
+                        ])
+                    ])
+                ])
+            ])
         ])],
         ["north horon", "underwater item below natzu bridge", False, lambda state: oos_can_swim(state, player, False)],
 
         ["north horon", "temple remains lower stump", True, lambda state: oos_can_jump_3_wide_pit(state, player)],
+
+        ["ghastly stump", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
 
         ["ghastly stump", "mrs. ruul trade", False, lambda state: any([
             state.has("Ghastly Doll", player),
@@ -395,13 +475,11 @@ def make_holodrum_logic(player: int):
         ])],
 
         ["spool swamp north", "ghastly stump", False, None],
-        ["ghastly stump", "spool swamp north", False, lambda state: all([
-            any([
-                oos_season_in_holodrum_plain(state, player, SEASON_SUMMER),
-                oos_can_jump_4_wide_pit(state, player),
-                oos_can_summon_ricky(state, player),
-                oos_can_summon_moosh(state, player)
-            ])
+        ["ghastly stump", "spool swamp north", False, lambda state: any([
+            oos_season_in_holodrum_plain(state, player, SEASON_SUMMER),
+            oos_can_jump_4_wide_pit(state, player),
+            oos_can_summon_ricky(state, player),
+            oos_can_summon_moosh(state, player)
         ])],
 
         ["ghastly stump", "spool swamp south", True, lambda state: all([
@@ -427,6 +505,14 @@ def make_holodrum_logic(player: int):
 
         # SPOOL SWAMP #############################################################################################
 
+        ["spool swamp north", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+        
         ["spool swamp north", "spool swamp tree", False, lambda state: oos_can_harvest_tree(state, player, True)],
 
         ["spool swamp north", "floodgate keeper's house", False, lambda state: any([
@@ -455,24 +541,44 @@ def make_holodrum_logic(player: int):
         ["floodgate keyhole", "spool stump", False, lambda state: state.has("Floodgate Key", player)],
 
         ["spool stump", "d3 entrance", False, lambda state: oos_season_in_spool_swamp(state, player, SEASON_SUMMER)],
-        ["d3 entrance", "spool stump", False, lambda state: any([
-            # Jumping down D3 entrance without having a way to put summer is a risky situation, so expect player
-            # to have a way to warp out
-            oos_season_in_spool_swamp(state, player, SEASON_SUMMER),
-            oos_can_warp(state, player)
-        ])],
 
         ["spool stump", "spool swamp middle", False, lambda state: any([
             oos_get_default_season(state, player, "SPOOL_SWAMP") != SEASON_SPRING,
             oos_can_remove_season(state, player, SEASON_SPRING),
-            oos_has_flippers(state, player),
-            oos_can_summon_dimitri(state, player)
+            oos_can_swim(state, player, True)
         ])],
 
         ["spool swamp middle", "spool swamp south near gasha spot", False, lambda state: oos_can_summon_ricky(state, player)],
         ["spool swamp south near gasha spot", "spool swamp middle", False, lambda state: any([
-            oos_has_feather(state, player),
-            oos_can_break_bush(state, player, True)
+            oos_can_summon_ricky(state, player),
+            all([
+                oos_has_feather(state, player),
+                any([
+                    oos_has_magic_boomerang(state, player),
+                    all([
+                        oos_option_medium_logic(state, player),
+                        any([
+                            oos_has_sword(state, player),
+                            all([
+                                oos_has_slingshot(state, player),
+                                oos_can_use_ember_seeds(state, player, False),
+                            ]),
+                            all([
+                                oos_has_bombs(state, player, 2),
+                                oos_option_hard_logic(state, player)
+                            ])
+                        ])
+                    ])
+                ])
+            ])
+        ])],
+
+        ["spool swamp south near gasha spot", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
         ])],
 
         ["spool swamp south near gasha spot", "spool swamp portal", True, lambda state: oos_has_bracelet(state, player)],
@@ -480,44 +586,89 @@ def make_holodrum_logic(player: int):
         ["spool swamp middle", "spool swamp south", True, lambda state: any([
             oos_can_jump_2_wide_pit(state, player),
             oos_can_summon_moosh(state, player),
-            oos_can_summon_dimitri(state, player),
-            oos_has_flippers(state, player)
+            oos_can_swim(state, player, True)
         ])],
 
-        ["spool swamp south", "spool swamp south (winter)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_WINTER)],
+        ["spool swamp south", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+
+        # make sure you can go directly from the stump to south, or default season
+        # just because you can reach the stump doesn't mean you can also get there
+        # ex. only access to gasha section is through subrosia
         ["spool swamp south", "spool swamp south (spring)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_SPRING)],
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_SPRING],
+        ["spool stump", "spool swamp south (spring)", False, lambda state: all([
+            oos_has_spring(state, player),
+            oos_can_swim(state, player, True),
+            any([
+                oos_can_summon_ricky(state, player),
+                oos_can_summon_moosh(state, player),
+                oos_can_jump_2_wide_pit(state, player)
+            ])
+        ])]
         ["spool swamp south", "spool swamp south (summer)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_SUMMER)],
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_SUMMER],
+        ["spool stump", "spool swamp south (summer)", False, lambda state: all([
+            oos_has_summer(state, player),
+            any([
+                oos_can_swim(state, player, True),
+                oos_can_summon_ricky(state, player),
+                oos_can_summon_moosh(state, player),
+                oos_can_jump_2_wide_pit(state, player)
+            ])
+        ])]
         ["spool swamp south", "spool swamp south (autumn)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_AUTUMN)],
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_AUTUMN],
+        ["spool stump", "spool swamp south (autumn)", False, lambda state: all([
+            oos_has_autumn(state, player),
+            any([
+                oos_can_swim(state, player, True),
+                oos_can_summon_ricky(state, player),
+                oos_can_summon_moosh(state, player),
+                oos_can_jump_2_wide_pit(state, player)
+            ])
+        ])]
+        ["spool swamp south", "spool swamp south (winter)", False, lambda state: \
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_WINTER],
+        ["spool stump", "spool swamp south (winter)", False, lambda state: all([
+            oos_has_winter(state, player),
+            any([
+                oos_can_swim(state, player, True),
+                oos_can_summon_ricky(state, player),
+                oos_can_summon_moosh(state, player),
+                oos_can_jump_2_wide_pit(state, player)
+            ])
+        ])]
         ["spool swamp south (winter)", "spool swamp south", False, None],
         ["spool swamp south (spring)", "spool swamp south", False, None],
         ["spool swamp south (summer)", "spool swamp south", False, None],
         ["spool swamp south (autumn)", "spool swamp south", False, None],
 
         ["spool swamp south (spring)", "spool swamp south near gasha spot", False, lambda state: \
-            oos_can_break_flowers(state, player, True)
-         ],
+            oos_can_break_flowers(state, player, True)],
         ["spool swamp south (winter)", "spool swamp south near gasha spot", False, lambda state: \
-            oos_can_remove_snow(state, player, True)
-         ],
+            oos_can_remove_snow(state, player, True)],
         ["spool swamp south (summer)", "spool swamp south near gasha spot", False, None],
         ["spool swamp south (autumn)", "spool swamp south near gasha spot", False, None],
 
+        # default season only because of the portal
         ["spool swamp south near gasha spot", "spool swamp south (spring)", False, lambda state: all([
-            oos_season_in_spool_swamp(state, player, SEASON_SPRING),
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_SPRING,
             oos_can_break_flowers(state, player, True)
         ])],
+        ["spool swamp south near gasha spot", "spool swamp south (summer)", False, lambda state: \
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_SUMMER],
+        ["spool swamp south near gasha spot", "spool swamp south (autumn)", False, lambda state: \
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_AUTUMN],
         ["spool swamp south near gasha spot", "spool swamp south (winter)", False, lambda state: all([
-            oos_season_in_spool_swamp(state, player, SEASON_WINTER),
+            oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_WINTER,
             oos_can_remove_snow(state, player, True)
         ])],
-        ["spool swamp south near gasha spot", "spool swamp south (summer)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_SUMMER)],
-        ["spool swamp south near gasha spot", "spool swamp south (autumn)", False, lambda state: \
-            oos_season_in_spool_swamp(state, player, SEASON_AUTUMN)],
 
         ["spool swamp south (winter)", "spool swamp cave", False, lambda state: all([
             oos_can_remove_snow(state, player, True),
@@ -529,14 +680,22 @@ def make_holodrum_logic(player: int):
 
         # NATZU REGION #############################################################################################
 
-        ["north horon", "natzu west", True, lambda state: any([
-            oos_can_jump_1_wide_pit(state, player, True),
-            oos_can_swim(state, player, True)
-        ])],
+        ["north horon", "natzu west", True, None],
 
         ["natzu west", "natzu west (ricky)", True, lambda state: oos_is_companion_ricky(state, player)],
         ["natzu west", "natzu west (moosh)", True, lambda state: oos_is_companion_moosh(state, player)],
         ["natzu west", "natzu west (dimitri)", True, lambda state: oos_is_companion_dimitri(state, player)],
+
+        ["natzu west (ricky)", "natzu east (ricky)", True, lambda state: oos_can_summon_ricky(state, player)],
+        ["natzu west (moosh)", "natzu east (moosh)", True, lambda state: any([
+            oos_can_summon_moosh(state, player),
+            all([
+                oos_option_medium_logic(state, player),
+                oos_can_break_bush(state, player, True),
+                oos_can_jump_3_wide_pit(state, player)
+            ])
+        ])],
+        ["natzu west (dimitri)", "natzu east (dimitri)", True, lambda state: oos_can_swim(state, player, True)],
 
         ["natzu east (ricky)", "sunken city", True, lambda state: oos_is_companion_ricky(state, player)],
         ["natzu east (moosh)", "sunken city", True, lambda state: all([
@@ -552,17 +711,6 @@ def make_holodrum_logic(player: int):
         ])],
         ["natzu east (dimitri)", "natzu region, across water", False, lambda state: \
             oos_can_jump_5_wide_liquid(state, player)],
-
-        ["natzu west (ricky)", "natzu east (ricky)", True, lambda state: oos_can_summon_ricky(state, player)],
-        ["natzu west (moosh)", "natzu east (moosh)", True, lambda state: any([
-            oos_can_summon_moosh(state, player),
-            all([
-                oos_option_medium_logic(state, player),
-                oos_can_break_bush(state, player, True),
-                oos_can_jump_3_wide_pit(state, player)
-            ])
-        ])],
-        ["natzu west (dimitri)", "natzu east (dimitri)", True, lambda state: oos_can_swim(state, player, True)],
 
         ["natzu east (ricky)", "moblin keep bridge", False, None],
         ["natzu east (moosh)", "moblin keep bridge", False, lambda state: any([
@@ -586,7 +734,7 @@ def make_holodrum_logic(player: int):
         ["moblin keep", "moblin keep chest", False, lambda state: any([
             oos_has_bracelet(state, player)
         ])],
-        ["moblin keep", "sunken city", False, lambda state: oos_can_warp(state, player)],
+        ["moblin keep", "sunken city", False, None],
 
         ["natzu east (ricky)", "natzu river bank", True, lambda state: oos_can_summon_ricky(state, player)],
         ["natzu east (moosh)", "natzu river bank", True, lambda state: oos_is_companion_moosh(state, player)],
@@ -687,13 +835,11 @@ def make_holodrum_logic(player: int):
                 all([
                     oos_season_in_mt_cucco(state, player, SEASON_SPRING),
                     any([
-                        oos_can_break_flowers(state, player, False),
-                        # Moosh can break flowers one way, but it won't be of any help when coming back so we need
-                        # to be able to warp out
-                        state.has("Spring Banana", player) and oos_can_warp(state, player),
+                        oos_can_break_flowers(state, player),
+                        state.has("Spring Banana", player),
                     ])
                 ]),
-                oos_option_hard_logic(state, player) and oos_can_warp(state, player),
+                oos_option_hard_logic(state, player)
             ]),
             oos_has_bracelet(state, player),  # to grab the rooster
         ])],
@@ -710,9 +856,15 @@ def make_holodrum_logic(player: int):
 
         ["mount cucco", "mt. cucco, talon's cave entrance", False, lambda state: \
             oos_season_in_mt_cucco(state, player, SEASON_SPRING)],
+        ["mt. cucco, talon's cave entrance", "mount cucco", False, None],
 
-        ["mt. cucco, talon's cave entrance", "talon trade", False, lambda state: state.has("Megaphone", player)],
-        ["talon trade", "mt. cucco, talon's cave", False, None],
+        ["mt. cucco, talon's cave entrance", "talon trade", False, lambda state: all([
+            state.has("Megaphone", player),
+            any([
+                oos_get_default_season(state, player, "SUNKEN_CITY") != SEASON_WINTER,
+                oos_can_remove_season(state, player, SEASON_WINTER)
+            ])
+        ])],
 
         ["mt. cucco, talon's cave entrance", "mt. cucco heart piece", False, None],
 
@@ -728,7 +880,7 @@ def make_holodrum_logic(player: int):
             state.has("Dragon Key", player),
             oos_has_summer(state, player)
         ])],
-        ["d4 entrance", "mt. cucco, talon's cave entrance", False, lambda state: oos_can_warp(state, player)],
+        ["d4 entrance", "mt. cucco, talon's cave entrance", False, None],
 
         ["mount cucco", "goron mountain, across pits", False, lambda state: any([
             state.has("Spring Banana", player),
@@ -736,13 +888,29 @@ def make_holodrum_logic(player: int):
         ])],
 
         ["mount cucco", "goron blocked cave entrance", False, lambda state: any([
-                oos_can_remove_snow(state, player, False),
-                state.has("Spring Banana", player)
+            oos_can_remove_snow(state, player, False),
+            state.has("Spring Banana", player)
         ])],
         ["goron blocked cave entrance", "mount cucco", False, lambda state: \
             oos_can_remove_snow(state, player, False)],
 
+        ["goron blocked cave entrance", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+
         ["goron blocked cave entrance", "goron mountain", True, lambda state: oos_has_bracelet(state, player)],
+
+        ["goron mountain", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
 
         ["goron blocked cave entrance", "goron's gift", False, lambda state: oos_has_bombs(state, player)],
 
@@ -774,14 +942,42 @@ def make_holodrum_logic(player: int):
         ["spool swamp north", "tarm ruins", False, lambda state: oos_has_required_jewels(state, player)],
 
         ["tarm ruins", "lost woods stump", False, lambda state: all([
-            oos_has_summer(state, player),
-            oos_has_winter(state, player),
+            any([
+                oos_season_in_lost_woods(state, player, SEASON_SUMMER),
+                all([
+                    oos_option_medium_logic(state, player),
+                    oos_has_magic_boomerang(state, player),
+                    any([
+                        oos_can_jump_1_wide_pit(state, player),
+                        oos_option_hard_logic(state, player)
+                    ])
+                ])
+            ]),
+            oos_season_in_lost_woods(state, player, SEASON_WINTER),
             oos_has_autumn(state, player),
             oos_can_break_mushroom(state, player, False)
         ])],
 
+        ["lost woods stump", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+
         ["lost woods stump", "lost woods", False, lambda state: oos_can_reach_lost_woods_pedestal(state, player)],
         ["lost woods stump", "d6 sector", False, lambda state: oos_can_complete_lost_woods_main_sequence(state, player)],
+        # special case for getting to pedestal using default season
+        ["d6 sector", "lost woods", False, lambda state: oos_can_reach_lost_woods_pedestal(state, player, True)],
+
+        ["d6 sector", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
 
         ["d6 sector", "tarm ruins tree", False, lambda state: oos_can_harvest_tree(state, player, False)],
         ["d6 sector", "tarm ruins, under tree", False, lambda state: all([
@@ -797,17 +993,19 @@ def make_holodrum_logic(player: int):
                 oos_can_use_ember_seeds(state, player, False)
             ]),
             oos_season_in_tarm_ruins(state, player, SEASON_SPRING),
-            oos_can_break_flowers(state, player, False)
+            oos_can_break_flowers(state, player)
         ])],
         ["d6 sector", "old man near d6", False, lambda state: all([
             oos_season_in_tarm_ruins(state, player, SEASON_WINTER),
             oos_season_in_tarm_ruins(state, player, SEASON_SPRING),
-            oos_can_break_flowers(state, player, False),
+            oos_can_break_flowers(state, player),
             oos_can_use_ember_seeds(state, player, False)
         ])],
         # When coming from D6 entrance, the pillar needs to be broken during spring to be able to go backwards
-        ["d6 entrance", "d6 sector", False, lambda state:
-            oos_get_default_season(state, player, "TARM_RUINS") == SEASON_SPRING],
+        ["d6 entrance", "d6 sector", False, lambda state: all([
+            oos_get_default_season(state, player, "TARM_RUINS") == SEASON_SPRING,
+            oos_can_break_flowers(state, player)
+        ])],
 
         # SAMASA DESERT ######################################################################################
 
@@ -819,72 +1017,84 @@ def make_holodrum_logic(player: int):
 
         # TEMPLE REMAINS ####################################################################################
 
-        ["temple remains lower stump", "temple remains upper stump", False, lambda state: any([
-            all([  # Winter rule
+        ["temple remains lower stump", "maple trade", False, lambda state: all([
+            oos_can_meet_maple(state, player),
+            any([
+                state.has("Lon Lon Egg", player),
+                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+            ])
+        ])],
+        
+        ["temple remains lower stump", "temple remains upper stump", False, lambda state: all([
+            # connection is useless once volcano is triggered
+            # just block it so it's less confusing for logic
+            not state.has("_triggered_volcano", player),
+            any([
+                all([  # Winter rule
+                    oos_season_in_temple_remains(state, player, SEASON_WINTER),
+                    oos_can_remove_snow(state, player, False),
+                    oos_can_break_bush(state, player, False),
+                    oos_can_jump_6_wide_pit(state, player)
+                ]),
+                all([  # Summer rule
+                    oos_season_in_temple_remains(state, player, SEASON_SUMMER),
+                    oos_can_break_bush(state, player, False),
+                    oos_can_jump_6_wide_pit(state, player)
+                ]),
+                all([  # Spring rule
+                    oos_season_in_temple_remains(state, player, SEASON_SPRING),
+                    oos_can_break_flowers(state, player),
+                    oos_can_break_bush(state, player, False),
+                    oos_can_jump_6_wide_pit(state, player)
+                ]),
+                all([  # Autumn rule
+                    oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
+                    oos_can_break_bush(state, player)
+                ])
+            ])
+        ])],
+        ["temple remains upper stump", "temple remains lower stump", False, lambda state: all([
+            # connection is useless once volcano is triggered
+            # just block it so it's less confusing for logic
+            not state.has("_triggered_volcano", player),
+            any([
+                # Winter rule
                 oos_season_in_temple_remains(state, player, SEASON_WINTER),
-                oos_can_remove_snow(state, player, False),
-                oos_can_break_bush(state, player, False),
-                oos_can_jump_6_wide_pit(state, player)
-            ]),
-            all([  # Summer rule
-                oos_season_in_temple_remains(state, player, SEASON_SUMMER),
-                oos_can_break_bush(state, player, False),
-                oos_can_jump_6_wide_pit(state, player)
-            ]),
-            all([  # Spring rule
-                oos_season_in_temple_remains(state, player, SEASON_SPRING),
-                oos_can_break_flowers(state, player, False),
-                oos_can_break_bush(state, player, False),
-                oos_can_jump_6_wide_pit(state, player)
-            ]),
-            all([  # Autumn rule
-                oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
-                oos_can_break_bush(state, player)
+                all([  # Summer rule
+                    oos_season_in_temple_remains(state, player, SEASON_SUMMER),
+                    oos_can_break_bush(state, player, False),
+                    oos_can_jump_6_wide_pit(state, player)
+                ]),
+                all([  # Spring rule
+                    oos_season_in_temple_remains(state, player, SEASON_SPRING),
+                    oos_can_break_flowers(state, player),
+                    oos_can_break_bush(state, player, False),
+                    oos_can_jump_6_wide_pit(state, player)
+                ]),
+                all([  # Autumn rule
+                    oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
+                    oos_can_break_bush(state, player)
+                ])
             ])
         ])],
-        ["temple remains upper stump", "temple remains lower stump", False, lambda state: any([
-            # Winter rule
-            oos_season_in_temple_remains(state, player, SEASON_WINTER),
-            all([  # Summer rule
-                oos_season_in_temple_remains(state, player, SEASON_SUMMER),
-                oos_can_break_bush(state, player, False),
-                oos_can_jump_6_wide_pit(state, player)
-            ]),
-            all([  # Spring rule
-                oos_season_in_temple_remains(state, player, SEASON_SPRING),
-                oos_can_break_flowers(state, player, False),
-                oos_can_break_bush(state, player, False),
-                oos_can_jump_6_wide_pit(state, player)
-            ]),
-            all([  # Autumn rule
-                oos_season_in_temple_remains(state, player, SEASON_AUTUMN),
-                oos_can_break_bush(state, player)
-            ])
-        ])],
+
+        ["temple remains lower stump", "temple remains lower portal access", False, lambda state: all([
+            state.has("_triggered_volcano", player),
+            oos_has_feather(state, player)
+        ])]
 
         ["temple remains upper stump", "temple remains lower portal access", False, lambda state: all([
-            oos_season_in_temple_remains(state, player, SEASON_WINTER),
-            oos_can_jump_1_wide_pit(state, player, False)
-        ])],
-
-        ["temple remains lower portal access", "temple remains upper stump", False, lambda state: any([
-            # Portal can be escaped only if default season is winter or if volcano erupted
-            all([
-                oos_get_default_season(state, player, "TEMPLE_REMAINS") == SEASON_WINTER,
-                oos_can_jump_1_wide_pit(state, player, False)
-            ]),
-            all([
-                state.has("_triggered_volcano", player),
-                oos_can_jump_2_wide_liquid(state, player)
-            ]),
+            # connection is useless once volcano is triggered
+            # just block it so it's less confusing for logic
+            not state.has("_triggered_volcano", player),
+            oos_has_winter(state, player, SEASON_WINTER),
+            oos_has_feather(state, player)
         ])],
 
         ["temple remains lower portal access", "temple remains lower portal", True, None],
 
-        ["temple remains lower portal", "temple remains lower stump", False, lambda state: \
-            # There is an added ledge in rando that enables jumping from the portal down to the stump, whatever
-            # the season is, but it is a risky action so we ask for the player to be able to warp back
-            oos_can_warp(state, player)],
+        # There is an added ledge in rando that enables jumping from the portal down to the stump, whatever the season is
+        ["temple remains lower portal", "temple remains lower stump", False, None],
 
         ["temple remains lower stump", "temple remains heart piece", False, lambda state: all([
             state.has("_triggered_volcano", player),
@@ -906,11 +1116,20 @@ def make_holodrum_logic(player: int):
             oos_can_jump_1_wide_liquid(state, player, False)
         ])],
 
-        ["temple remains upper portal", "temple remains upper stump", False, lambda state: \
-            oos_can_jump_1_wide_pit(state, player, False)],
+        ["temple remains upper portal", "temple remains upper stump", False, lambda state: all([
+            # connection is useless once volcano is triggered
+            # just block it so it's less confusing for logic
+            not state.has("_triggered_volcano", player),
+            oos_can_jump_1_wide_pit(state, player, False)
+        ])],
 
-        ["temple remains upper portal", "temple remains lower portal access", False, lambda state: \
-            oos_get_default_season(state, player, "TEMPLE_REMAINS") == SEASON_WINTER],
+        ["temple remains upper portal", "temple remains lower portal access", False, lambda state: any([
+            oos_can_jump_1_wide_pit(state, player),
+            all([
+                not state.has("_triggered_volcano", player),
+                oos_get_default_season(state, player, "TEMPLE_REMAINS") == SEASON_WINTER
+            ])
+        ])],
 
 
         # ONOX CASTLE #############################################################################################
@@ -955,7 +1174,18 @@ def make_holodrum_logic(player: int):
             ])
         ])],
         ["tarm ruins", "golden lynel", False, lambda state: all([
-            oos_season_in_lost_woods(state, player, SEASON_SUMMER),
+            any([
+                oos_season_in_lost_woods(state, player, SEASON_SUMMER),
+                all([
+                    oos_option_medium_logic(state, player),
+                    oos_season_in_lost_woods(state, player, SEASON_AUTUMN),
+                    oos_has_magic_boomerang(state, player),
+                    any([
+                        oos_can_jump_1_wide_pit(state, player),
+                        oos_option_hard_logic(state, player)
+                    ])
+                ])
+            ]),
             oos_season_in_lost_woods(state, player, SEASON_WINTER),
             any([
                 oos_has_sword(state, player),
@@ -982,7 +1212,7 @@ def make_holodrum_logic(player: int):
         # GASHA TREES #############################################################################################
 
         ["horon village", "horon gasha spot", False, None],
-        ["horon village", "impa gasha spot", False, lambda state: oos_can_break_bush(state, player, True)],
+        ["impa's house", "impa gasha spot", False, lambda state: oos_can_break_bush(state, player, True)],
         ["suburbs", "suburbs gasha spot", False, lambda state: oos_can_break_bush(state, player, True)],
         ["ghastly stump", "holodrum plain gasha spot", False, lambda state: all([
             oos_can_break_bush(state, player, True),

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -3,7 +3,11 @@ from .LogicPredicates import *
 
 def make_holodrum_logic(player: int, origin_name: str):
     return [
-        ["impa's house", "horon village", True, None],
+        ["maple encounter", "maple trade", False, lambda state: any([
+            state.has("Lon Lon Egg", player),
+            oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
+        ])],
+
         ["horon village", "mayor's gift", False, None],
         ["horon village", "vasu's gift", False, None],
         ["horon village", "mayor's house secret room", False, lambda state: oos_has_bombs(state, player)],
@@ -55,13 +59,8 @@ def make_holodrum_logic(player: int, origin_name: str):
         # WESTERN COAST ##############################################################################################
 
         ["horon village", "western coast", True, None],
-        ["western coast", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["western coast", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["western coast", "black beast's chest", False, lambda state: all([
             all([
                 oos_has_slingshot(state, player),
@@ -126,13 +125,8 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         ["horon village", "suburbs", True, lambda state: oos_can_use_ember_seeds(state, player, False)],
 
-        ["suburbs", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["suburbs", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["suburbs", "windmill heart piece", False, lambda state: oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)],
         ["suburbs", "guru-guru trade", False, lambda state: any([
             state.has("Engine Grease", player),
@@ -155,23 +149,13 @@ def make_holodrum_logic(player: int, origin_name: str):
             oos_can_swim(state, player, True),
             oos_can_jump_1_wide_liquid(state, player, True)
         ])],
-        ["suburbs fairy fountain", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["suburbs fairy fountain", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["suburbs", "suburbs fairy fountain (winter)", True, lambda state: any([
             oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)
         ])],
-        ["suburbs fairy fountain (winter)", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["suburbs fairy fountain (winter)", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["suburbs fairy fountain (winter)", "suburbs fairy fountain", False, lambda state: \
             oos_can_remove_season(state, player, SEASON_WINTER)],
         ["suburbs fairy fountain", "suburbs fairy fountain (winter)", False, lambda state: \
@@ -188,13 +172,8 @@ def make_holodrum_logic(player: int, origin_name: str):
         ["moblin road", "suburbs fairy fountain (winter)", False, lambda state: \
             oos_season_in_eastern_suburbs(state, player, SEASON_WINTER)],
         
-        ["moblin road", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["moblin road", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["sunken city", "moblin road", False, lambda state: all([
             oos_has_flippers(state, player),
@@ -253,13 +232,9 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         # EYEGLASS LAKE SECTOR #########################################################################################
 
-        ["impa's house", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["impa's house", "horon village", True, None],
+        ["impa's house", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["impa's house", "eyeglass lake, across bridge", False, lambda state: any([
             oos_can_jump_4_wide_pit(state, player),
             all([
@@ -320,13 +295,8 @@ def make_holodrum_logic(player: int, origin_name: str):
             oos_can_jump_1_wide_pit(state, player, True)
         ])],
 
-        ["d5 stump", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["d5 stump", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["d5 stump", "eyeglass lake (default)", True, lambda state: all([
             any([
@@ -417,13 +387,8 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         # NORTH HORON / HOLODRUM PLAIN ###############################################################################
 
-        ["north horon", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["north horon", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         ["north horon", "north horon tree", False, lambda state: oos_can_harvest_tree(state, player, True)],
         ["north horon", "blaino prize", False, lambda state: oos_can_farm_rupees(state, player)],
         ["north horon", "cave north of D1", False, lambda state: all([
@@ -453,13 +418,8 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         ["north horon", "temple remains lower stump", True, lambda state: oos_can_jump_3_wide_pit(state, player)],
 
-        ["ghastly stump", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["ghastly stump", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["ghastly stump", "mrs. ruul trade", False, lambda state: any([
             state.has("Ghastly Doll", player),
@@ -503,13 +463,8 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         # SPOOL SWAMP #############################################################################################
 
-        ["spool swamp north", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["spool swamp north", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         
         ["spool swamp north", "spool swamp tree", False, lambda state: oos_can_harvest_tree(state, player, True)],
 
@@ -571,13 +526,8 @@ def make_holodrum_logic(player: int, origin_name: str):
             ])
         ])],
 
-        ["spool swamp south near gasha spot", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["spool swamp south near gasha spot", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["spool swamp south near gasha spot", "spool swamp portal", True, lambda state: oos_has_bracelet(state, player)],
 
@@ -587,13 +537,8 @@ def make_holodrum_logic(player: int, origin_name: str):
             oos_can_swim(state, player, True)
         ])],
 
-        ["spool swamp south", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["spool swamp south", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         # make sure you can go directly from the stump to south, or default season
         # just because you can reach the stump doesn't mean you can also get there
@@ -892,23 +837,13 @@ def make_holodrum_logic(player: int, origin_name: str):
         ["goron blocked cave entrance", "mount cucco", False, lambda state: \
             oos_can_remove_snow(state, player, False)],
 
-        ["goron blocked cave entrance", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["goron blocked cave entrance", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["goron blocked cave entrance", "goron mountain", True, lambda state: oos_has_bracelet(state, player)],
 
-        ["goron mountain", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["goron mountain", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["goron blocked cave entrance", "goron's gift", False, lambda state: oos_has_bombs(state, player)],
 
@@ -956,13 +891,8 @@ def make_holodrum_logic(player: int, origin_name: str):
             oos_can_break_mushroom(state, player, False)
         ])],
 
-        ["lost woods stump", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["lost woods stump", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["lost woods stump", "lost woods", False, lambda state: oos_can_reach_lost_woods_pedestal(state, player)],
         # special case for getting to d6 using default season
@@ -977,13 +907,8 @@ def make_holodrum_logic(player: int, origin_name: str):
             oos_option_medium_logic(state, player)
         ])],
 
-        ["d6 sector", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["d6 sector", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
 
         ["d6 sector", "tarm ruins tree", False, lambda state: oos_can_harvest_tree(state, player, False)],
         ["d6 sector", "tarm ruins, under tree", False, lambda state: all([
@@ -1023,13 +948,8 @@ def make_holodrum_logic(player: int, origin_name: str):
 
         # TEMPLE REMAINS ####################################################################################
 
-        ["temple remains lower stump", "maple trade", False, lambda state: all([
-            oos_can_meet_maple(state, player),
-            any([
-                state.has("Lon Lon Egg", player),
-                oos_self_locking_item(state, player, "maple trade", "Lon Lon Egg")
-            ])
-        ])],
+        ["temple remains lower stump", "maple encounter", False, lambda state: 
+            oos_can_meet_maple(state, player)],
         
         ["temple remains lower stump", "temple remains upper stump", False, lambda state: any([
             all([  # Volcano rule

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -442,7 +442,7 @@ def make_holodrum_logic(player: int):
                     # can get from the stump to old man in summer
                     oos_has_summer(state, player),
                     any([
-                        oos_has_feather(state, player),
+                        oos_can_jump_1_wide_pit(state, player, True),
                         all([
                             oos_can_break_bush(state, player, True),
                             oos_can_swim(state, player, True)

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -967,9 +967,17 @@ def make_holodrum_logic(player: int):
         ])],
 
         ["lost woods stump", "lost woods", False, lambda state: oos_can_reach_lost_woods_pedestal(state, player)],
+        # special case for getting to d6 using default season
+        ["lost woods", "d6 sector", False, lambda state: all([
+            oos_can_complete_lost_woods_main_sequence(state, player, True),
+            oos_option_medium_logic(state, player)
+        ])],
         ["lost woods stump", "d6 sector", False, lambda state: oos_can_complete_lost_woods_main_sequence(state, player)],
         # special case for getting to pedestal using default season
-        ["d6 sector", "lost woods", False, lambda state: oos_can_reach_lost_woods_pedestal(state, player, True)],
+        ["d6 sector", "lost woods", False, lambda state: all([
+            oos_can_reach_lost_woods_pedestal(state, player, True),
+            oos_option_medium_logic(state, player)
+        ])],
 
         ["d6 sector", "maple trade", False, lambda state: all([
             oos_can_meet_maple(state, player),

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -1104,10 +1104,12 @@ def make_holodrum_logic(player: int, origin_name: str):
                         oos_option_hard_logic(state, player),
                         oos_can_use_seeds(state, player),
                         # satchel can't use pegasus to damage, but all others work
-                        oos_has_ember_seeds(state, player),
-                        oos_has_mystery_seeds(state, player),
-                        oos_has_scent_seeds(state, player),
-                        oos_has_gale_seeds(state, player)
+                        any([
+                            oos_has_ember_seeds(state, player),
+                            oos_has_mystery_seeds(state, player),
+                            oos_has_scent_seeds(state, player),
+                            oos_has_gale_seeds(state, player)
+                        ])
                     ])
                 ])
             ])

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -1,7 +1,7 @@
 from .LogicPredicates import *
 
 
-def make_holodrum_logic(player: int):
+def make_holodrum_logic(player: int, origin_name: str):
     return [
         ["impa's house", "horon village", True, None],
         ["horon village", "mayor's gift", False, None],
@@ -1263,7 +1263,7 @@ def make_holodrum_logic(player: int):
         ["western coast after ship", "western coast gasha spot", False, None],
         ["north horon", "onox gasha spot", False, lambda state: oos_has_shovel(state, player)],
 
-        ["Menu", "gasha tree 1",  False, lambda state: oos_can_harvest_gasha(state, player, 1)],
+        [origin_name, "gasha tree 1",  False, lambda state: oos_can_harvest_gasha(state, player, 1)],
         ["gasha tree 1", "gasha tree 2",  False, lambda state: oos_can_harvest_gasha(state, player, 2)],
         ["gasha tree 2", "gasha tree 3",  False, lambda state: oos_can_harvest_gasha(state, player, 3)],
         ["gasha tree 3", "gasha tree 4",  False, lambda state: oos_can_harvest_gasha(state, player, 4)],

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -3,8 +3,6 @@ from .LogicPredicates import *
 
 def make_holodrum_logic(player: int):
     return [
-        ["Menu", "impa's house", False, None],
-
         ["impa's house", "horon village", True, None],
         ["horon village", "mayor's gift", False, None],
         ["horon village", "vasu's gift", False, None],

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -1086,10 +1086,31 @@ def make_holodrum_logic(player: int, origin_name: str):
             ])
         ])],
 
-        ["onox beaten", "ganon beaten", False, lambda state: all([
-            oos_has_sword(state, player, False),
-            oos_has_slingshot(state, player),
-            oos_can_use_ember_seeds(state, player, True),
+        ["onox beaten", "ganon beaten", False, lambda state: any([
+            all([
+                # casual rules
+                oos_has_noble_sword(state, player),
+                oos_has_slingshot(state, player),
+                oos_can_use_ember_seeds(state, player, False),
+                oos_can_use_mystery_seeds(state, player)
+            ]),
+            all([
+                oos_option_medium_logic(state, player),
+                oos_has_sword(state, player, False),
+                any([
+                    # all seeds damage Twinrova phase 2
+                    oos_has_slingshot(state, player),
+                    all([
+                        oos_option_hard_logic(state, player),
+                        oos_can_use_seeds(state, player),
+                        # satchel can't use pegasus to damage, but all others work
+                        oos_has_ember_seeds(state, player),
+                        oos_has_mystery_seeds(state, player),
+                        oos_has_scent_seeds(state, player),
+                        oos_has_gale_seeds(state, player)
+                    ])
+                ])
+            ])
         ])],
 
         # GOLDEN BEASTS #############################################################################################

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -5,7 +5,7 @@ def make_holodrum_logic(player: int):
     return [
         ["Menu", "impa's house", False, None],
 
-        ["impa's house", "horon village", True, None]
+        ["impa's house", "horon village", True, None],
         ["horon village", "mayor's gift", False, None],
         ["horon village", "vasu's gift", False, None],
         ["horon village", "mayor's house secret room", False, lambda state: oos_has_bombs(state, player)],
@@ -610,7 +610,7 @@ def make_holodrum_logic(player: int):
                 oos_can_summon_moosh(state, player),
                 oos_can_jump_2_wide_pit(state, player)
             ])
-        ])]
+        ])],
         ["spool swamp south", "spool swamp south (summer)", False, lambda state: \
             oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_SUMMER],
         ["spool stump", "spool swamp south (summer)", False, lambda state: all([
@@ -621,7 +621,7 @@ def make_holodrum_logic(player: int):
                 oos_can_summon_moosh(state, player),
                 oos_can_jump_2_wide_pit(state, player)
             ])
-        ])]
+        ])],
         ["spool swamp south", "spool swamp south (autumn)", False, lambda state: \
             oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_AUTUMN],
         ["spool stump", "spool swamp south (autumn)", False, lambda state: all([
@@ -632,7 +632,7 @@ def make_holodrum_logic(player: int):
                 oos_can_summon_moosh(state, player),
                 oos_can_jump_2_wide_pit(state, player)
             ])
-        ])]
+        ])],
         ["spool swamp south", "spool swamp south (winter)", False, lambda state: \
             oos_get_default_season(state, player, "SPOOL_SWAMP") == SEASON_WINTER],
         ["spool stump", "spool swamp south (winter)", False, lambda state: all([
@@ -643,7 +643,7 @@ def make_holodrum_logic(player: int):
                 oos_can_summon_moosh(state, player),
                 oos_can_jump_2_wide_pit(state, player)
             ])
-        ])]
+        ])],
         ["spool swamp south (winter)", "spool swamp south", False, None],
         ["spool swamp south (spring)", "spool swamp south", False, None],
         ["spool swamp south (summer)", "spool swamp south", False, None],
@@ -948,7 +948,7 @@ def make_holodrum_logic(player: int):
                     oos_option_medium_logic(state, player),
                     oos_has_magic_boomerang(state, player),
                     any([
-                        oos_can_jump_1_wide_pit(state, player),
+                        oos_can_jump_1_wide_pit(state, player, False),
                         oos_option_hard_logic(state, player)
                     ])
                 ])
@@ -1089,13 +1089,13 @@ def make_holodrum_logic(player: int):
         ["temple remains lower stump", "temple remains lower portal access", False, lambda state: all([
             state.has("_triggered_volcano", player),
             oos_has_feather(state, player)
-        ])]
+        ])],
 
         ["temple remains upper stump", "temple remains lower portal access", False, lambda state: all([
             # connection is useless once volcano is triggered
             # just block it so it's less confusing for logic
             not state.has("_triggered_volcano", player),
-            oos_has_winter(state, player, SEASON_WINTER),
+            oos_has_winter(state, player),
             oos_has_feather(state, player)
         ])],
 
@@ -1132,7 +1132,7 @@ def make_holodrum_logic(player: int):
         ])],
 
         ["temple remains upper portal", "temple remains lower portal access", False, lambda state: any([
-            oos_can_jump_1_wide_pit(state, player),
+            oos_can_jump_1_wide_pit(state, player, False),
             all([
                 not state.has("_triggered_volcano", player),
                 oos_get_default_season(state, player, "TEMPLE_REMAINS") == SEASON_WINTER
@@ -1189,7 +1189,7 @@ def make_holodrum_logic(player: int):
                     oos_season_in_lost_woods(state, player, SEASON_AUTUMN),
                     oos_has_magic_boomerang(state, player),
                     any([
-                        oos_can_jump_1_wide_pit(state, player),
+                        oos_can_jump_1_wide_pit(state, player, False),
                         oos_option_hard_logic(state, player)
                     ])
                 ])

--- a/worlds/tloz_oos/data/logic/SubrosiaLogic.py
+++ b/worlds/tloz_oos/data/logic/SubrosiaLogic.py
@@ -13,6 +13,7 @@ def make_subrosia_logic(player: int):
         ["volcanoes west portal", "subrosia volcano sector", True, None],
         ["d8 entrance portal", "d8 entrance", True, None],
 
+        # TODO when alt starting locations are implemented, there probably needs to be a way to re-use this forced transition
         ["subrosia pirates sector", "western coast after ship", False, lambda state: state.has("Pirate's Bell", player)],
 
         # Regions ###############################################################


### PR DESCRIPTION
Various logic updates
Removed can_warp requirements
Added "impa's house" and "western coast" regions just in case transition rando becomes a thing (and set Menu -> impa's house connection)
Added multiple Maple checks in prep for alternate starting locations