### PR TITLE
Logic/generation fixes

### DIFF
--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -578,6 +578,7 @@ class OracleOfSeasonsWorld(World):
         filler_item_count = 0
         rupee_item_count = 0
         ore_item_count = 0
+        remaining_rings = len({name for name, idata in ITEMS_DATA.items() if "ring" in idata}) - len(self.options.excluded_rings.value)
         for loc_name, loc_data in LOCATIONS_DATA.items():
             if not self.location_is_active(loc_name, loc_data):
                 continue
@@ -586,7 +587,12 @@ class OracleOfSeasonsWorld(World):
 
             item_name = loc_data['vanilla_item']
             if "Ring" in item_name:
-                item_name = "Random Ring"
+                if remaining_rings > 0:
+                    item_name = "Random Ring"
+                    remaining_rings -= 1
+                else:
+                    filler_item_count += 1
+                    continue
             if item_name in removed_item_quantities and removed_item_quantities[item_name] > 0:
                 # If item was put in the "remove_items_from_pool" option, replace it with a random filler item
                 removed_item_quantities[item_name] -= 1
@@ -671,7 +677,7 @@ class OracleOfSeasonsWorld(World):
             ring_name = f"{ring_copy.pop()}!USEFUL"
             item_pool_dict[ring_name] = item_pool_dict.get(ring_name, 0) + 1
 
-            if item_pool_dict["Random Ring"] > 0:
+            if item_pool_dict.get("Random Ring", 0) > 0:
                 # Take from set ring pool first
                 item_pool_dict["Random Ring"] -= 1
             else:

--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -582,7 +582,6 @@ class OracleOfSeasonsWorld(World):
         filler_item_count = 0
         rupee_item_count = 0
         ore_item_count = 0
-        remaining_rings = len({name for name, idata in ITEMS_DATA.items() if "ring" in idata}) - len(self.options.excluded_rings.value)
         for loc_name, loc_data in LOCATIONS_DATA.items():
             if not self.location_is_active(loc_name, loc_data):
                 continue
@@ -591,12 +590,7 @@ class OracleOfSeasonsWorld(World):
 
             item_name = loc_data['vanilla_item']
             if "Ring" in item_name:
-                if remaining_rings > 0:
-                    item_name = "Random Ring"
-                    remaining_rings -= 1
-                else:
-                    filler_item_count += 1
-                    continue
+                item_name = "Random Ring"
             if item_name in removed_item_quantities and removed_item_quantities[item_name] > 0:
                 # If item was put in the "remove_items_from_pool" option, replace it with a random filler item
                 removed_item_quantities[item_name] -= 1
@@ -681,7 +675,7 @@ class OracleOfSeasonsWorld(World):
             ring_name = f"{ring_copy.pop()}!USEFUL"
             item_pool_dict[ring_name] = item_pool_dict.get(ring_name, 0) + 1
 
-            if item_pool_dict.get("Random Ring", 0) > 0:
+            if item_pool_dict["Random Ring"] > 0:
                 # Take from set ring pool first
                 item_pool_dict["Random Ring"] -= 1
             else:

--- a/worlds/tloz_oos/data/Constants.py
+++ b/worlds/tloz_oos/data/Constants.py
@@ -186,7 +186,7 @@ SECRETS = [
     "Subrosia: Smith Secret",
     "Subrosia: Piratian Secret",
     "Subrosia: Temple Secret",
-    "Natzu: Deku Secret",
+    "Natzu Region: Deku Secret",
     "Goron Mountain: Biggoron Secret",
     "Horon Village: Mayor Secret"
 ]

--- a/worlds/tloz_oos/data/Locations.py
+++ b/worlds/tloz_oos/data/Locations.py
@@ -2328,7 +2328,7 @@ LOCATIONS_DATA = {
         "map_tile": 0xb0,
         "symbolic_name": "templeSecret",
     },
-    "Natzu: Deku Secret": {
+    "Natzu Region: Deku Secret": {
         "region_id": "deku secret",
         "vanilla_item": "Filler Item",
         "conditional": True,

--- a/worlds/tloz_oos/data/logic/OverworldLogic.py
+++ b/worlds/tloz_oos/data/logic/OverworldLogic.py
@@ -102,8 +102,10 @@ def make_holodrum_logic(player: int, origin_name: str, options: OracleOfSeasonsO
         ])],
 
         ["western coast", "d0 entrance", True, None],
-        ["western coast", "d0 rupee chest", False, lambda state: \
-            oos_can_break_bush(state, player, True)],
+        ["western coast", "d0 rupee chest", False, lambda state: all([
+            not oos_option_no_d0_alt_entrance(state, player),
+            oos_can_break_bush(state, player, True)
+        ])],
 
         ["western coast after ship", "western coast", False, lambda state: all([
             state.has("_met_pirates", player),


### PR DESCRIPTION
## What is this fixing or adding?
- Fixed Hero's Cave alt entrance logic error
- Fixed Generation error when all rings are excluded
- Updated Natzu Deku secret name to match naming convention (Natzu -> Natzu Region)

## How was this tested?
Test generation
