### PR TITLE
Reuse and copy all state to improve pre_fill performance

### DIFF
--- a/worlds/tloz_oos/__init__.py
+++ b/worlds/tloz_oos/__init__.py
@@ -792,8 +792,9 @@ class OracleOfSeasonsWorld(World):
     def get_pre_fill_items(self):
         return self.pre_fill_items
 
-    def pre_fill(self) -> None:
-        self.pre_fill_dungeon_items()
+    @classmethod
+    def stage_pre_fill(cls, multiworld: MultiWorld):
+        cls.stage_pre_fill_dungeon_items(multiworld)
 
     def filter_confined_dungeon_items_from_pool(self, items: List[Item]):
         confined_dungeon_items = []
@@ -830,53 +831,73 @@ class OracleOfSeasonsWorld(World):
             items.remove(item)
         self.pre_fill_items.extend(confined_dungeon_items)
 
-    def pre_fill_dungeon_items(self):
+    @classmethod
+    def stage_pre_fill_dungeon_items(cls, multiworld: MultiWorld):
         # If keysanity is off, dungeon items can only be put inside local dungeon locations, and there are not so many
         # of those which makes them pretty crowded.
         # This usually ends up with generator not having anywhere to place a few small keys, making the seed unbeatable.
-        # To circumvent this, we perform a restricted pre-fill here, placing only those dungeon items
+        # To circumvent this, we perform a restricted pre-fills here, placing only those dungeon items
         # before anything else.
-        base_all_state = self.multiworld.get_all_state(False, collect_pre_fill_items=False, perform_sweep=False)
-        # Collect all pre_fill_items except our own and then sweep. This gives more accurate results in cases of item
+        oos_players = multiworld.get_game_players(cls.game)
+
+        base_all_state = multiworld.get_all_state(False, collect_pre_fill_items=False, perform_sweep=False)
+        # Collect all pre_fill_items except our OoS's and then sweep. This gives more accurate results in cases of item
         # plando being used to remove items from the item pool and placing them into locations locked behind pre_fill
         # items.
-        for player in self.multiworld.player_ids:
-            if player == self.player:
+        for player in multiworld.player_ids:
+            if player in oos_players:
                 continue
-            subworld = self.multiworld.worlds[player]
+            subworld = multiworld.worlds[player]
             for item in subworld.get_pre_fill_items():
                 subworld.collect(base_all_state, item)
         base_all_state.sweep_for_advancements()
 
-        for i in range(0, 9):
-            # Build a list of locations in this dungeon
-            dungeon_location_names = [name for name, loc in LOCATIONS_DATA.items()
-                                      if "dungeon" in loc and loc["dungeon"] == i]
-            dungeon_locations = [loc for loc in self.multiworld.get_locations(self.player)
-                                 if loc.name in dungeon_location_names and not loc.locked]
+        for filling_player in oos_players:
+            # Create a player-specific state for just the player that is filling dungeons.
+            per_player_base_all_state = base_all_state.copy()
+            # Collect the pre_fill_items() of all other OoS players into the state.
+            for other_player in oos_players:
+                if other_player == filling_player:
+                    continue
+                subworld = multiworld.worlds[other_player]
+                for item in subworld.get_pre_fill_items():
+                    subworld.collect(per_player_base_all_state, item)
+            # And then sweep the state to pick up pre-placed items.
+            per_player_base_all_state.sweep_for_advancements()
 
-            # From the list of all dungeon items that needs to be placed restrictively, only filter the ones for the
-            # dungeon we are currently processing.
-            confined_dungeon_items = [item for item in self.pre_fill_items
-                                      if item.name.endswith(f"({DUNGEON_NAMES[i]})")]
-            if len(confined_dungeon_items) == 0:
-                continue  # This list might be empty with some keysanity options
+            # Get the world for the player that is filling.
+            filling_world = multiworld.worlds[filling_player]
 
-            # Remove from the all_state the items we're about to place
-            for item in confined_dungeon_items:
-                self.pre_fill_items.remove(item)
-            collection_state = base_all_state.copy()
-            # Collect our remaining pre_fill_items into the state.
-            for item in self.get_pre_fill_items():
-                collection_state.collect(item, True)
-            # Sweep the copied state across the entire multiworld to again account for unusual item plando. It is also
-            # beneficial to pass as maximal a state as possible to fill_restrictive to reduce how much sweeping
-            # fill_restrictive must do.
-            collection_state.sweep_for_advancements()
-            # Perform a prefill to place confined items inside locations of this dungeon
-            self.random.shuffle(dungeon_locations)
-            fill_restrictive(self.multiworld, collection_state, dungeon_locations, confined_dungeon_items,
-                             single_player_placement=True, lock=True, allow_excluded=True)
+            # Fill each of this world's dungeons.
+            for i in range(0, 9):
+                # Build a list of locations in this dungeon
+                dungeon_location_names = [name for name, loc in LOCATIONS_DATA.items()
+                                          if "dungeon" in loc and loc["dungeon"] == i]
+                dungeon_locations = [loc for loc in multiworld.get_locations(filling_player)
+                                     if loc.name in dungeon_location_names and not loc.locked]
+
+                # From the list of all dungeon items that needs to be placed restrictively, only filter the ones for the
+                # dungeon we are currently processing.
+                confined_dungeon_items = [item for item in filling_world.pre_fill_items
+                                          if item.name.endswith(f"({DUNGEON_NAMES[i]})")]
+                if len(confined_dungeon_items) == 0:
+                    continue  # This list might be empty with some keysanity options
+
+                # Remove from the pre_fill_items the items we're about to place
+                for item in confined_dungeon_items:
+                    filling_world.pre_fill_items.remove(item)
+                collection_state = per_player_base_all_state.copy()
+                # Collect the remaining pre_fill_items into the state.
+                for item in filling_world.get_pre_fill_items():
+                    collection_state.collect(item, True)
+                # Sweep the copied state across the entire multiworld to again account for unusual item plando. It is
+                # also beneficial to pass as maximal a state as possible to fill_restrictive to reduce how much sweeping
+                # fill_restrictive must do.
+                collection_state.sweep_for_advancements()
+                # Perform a prefill to place confined items inside locations of this dungeon
+                filling_world.random.shuffle(dungeon_locations)
+                fill_restrictive(multiworld, collection_state, dungeon_locations, confined_dungeon_items,
+                                 single_player_placement=True, lock=True, allow_excluded=True)
 
     def pre_fill_seeds(self) -> None:
         # The prefill algorithm for seeds has a few constraints:


### PR DESCRIPTION
## What is this fixing or adding?

Re-uses a single 'all state' with no OoS pre_fill items in pre_fill by making copies of the state and then collecting pre_fill items into those copies instead.

This is further expanded in the second commit, where pre_fill is converted to stage_pre_fill, so that all OoS slots share the same starting 'all state' that is then used to produce a per-player 'all state' that is used to create states for each of the 9 dungeon fills.

## How was this tested?

I ran generations with 60 template OoS yamls with a fixed seed and observed the same item placements as before while seeing a noticeable improvement in pre_fill generation performance. I would suggest doing some additional testing with non-template options.

The first commit reduced each OoS world's pre_fill from about 2.0s to about 0.45s for me. The second commit reduced that to a further 0.317s on average, or 19.0s for the entire stage_pre_fill.

Note that stage_ methods are run after all non-stage_ methods for a particular step, so generation with a fixed seed alongside worlds other than OoS could produce different results compared to before this PR.

## Further suggestions beyond this PR

If an OoS slot does not have any items to fill in dungeons, then some of the code could be skipped for that slot to, improve performance further.